### PR TITLE
Have margins for paragraphs in ckeditor

### DIFF
--- a/web/studio/ASC.Web.Studio/UserControls/Common/ckeditor/contents.css
+++ b/web/studio/ASC.Web.Studio/UserControls/Common/ckeditor/contents.css
@@ -97,10 +97,6 @@ body
 	margin: 8px;
 }
 
-p {
-    margin: 0;
-}
-
 .cke_editable
 {
 	font-size: 12px;


### PR DESCRIPTION
Paragraphs should have margin. Otherwise users enter 2 line returns (inserting an empty paragraph). Comment/discussion pages and emails sending processing correctly interpret paragraphs, so with an empty paragraph between each real paragraph the result is enormous visual space between paragraphs. Having paragraph margins will avoid users entering double line returns.