### PR TITLE
Enhance exceptions with WebDav when the user have not write permission

### DIFF
--- a/module/ASC.Files.Thirdparty/Sharpbox/SharpBoxFolderDao.cs
+++ b/module/ASC.Files.Thirdparty/Sharpbox/SharpBoxFolderDao.cs
@@ -30,6 +30,7 @@ using System.Linq;
 using ASC.Common.Data.Sql.Expressions;
 using ASC.Core;
 using ASC.Files.Core;
+using ASC.Web.Files.Resources;
 using ASC.Web.Studio.Core;
 using AppLimit.CloudComputing.SharpBox;
 
@@ -140,7 +141,14 @@ namespace ASC.Files.Thirdparty.Sharpbox
             {
                 //Create with id
                 var savedfolder = SharpBoxProviderInfo.Storage.CreateFolder(MakePath(folder.ID));
-                return MakeId(savedfolder);
+				if(savedfolder != null)
+				{
+					return MakeId(savedfolder);	
+				}
+				else
+				{
+					throw new Exception(FilesCommonResource.ErrorMassage_SharpBoxException);
+				}
             }
             if (folder.ParentFolderID != null)
             {
@@ -149,7 +157,14 @@ namespace ASC.Files.Thirdparty.Sharpbox
                 folder.Title = GetAvailableTitle(folder.Title, parentFolder, IsExist);
 
                 var newFolder = SharpBoxProviderInfo.Storage.CreateFolder(folder.Title, parentFolder);
-                return MakeId(newFolder);
+				if(newFolder != null)
+				{
+					return MakeId(newFolder);	
+				}
+				else
+				{
+					throw new Exception(FilesCommonResource.ErrorMassage_SharpBoxException);
+				}
             }
             return null;
         }


### PR DESCRIPTION
No exceptions were thrown when a user does not have write privileges and tries to create a WebDav folder.
Better exception when a user doesn't have write privileges and try to create a file.