### PR TITLE
Update zh-CN translation of "Block for co-authors"

### DIFF
--- a/web/studio/ASC.Web.Studio/Products/Files/Resources/FilesUCResource.zh-CN.resx
+++ b/web/studio/ASC.Web.Studio/Products/Files/Resources/FilesUCResource.zh-CN.resx
@@ -209,7 +209,7 @@
     <value>了解更多…</value>
   </data>
   <data name="ButtonLock" xml:space="preserve">
-    <value>文本块</value>
+    <value>锁定协作编辑</value>
   </data>
   <data name="ButtonMoveCopy" xml:space="preserve">
     <value>移动或复制</value>


### PR DESCRIPTION
Signed-off-by: Andy Song <wsong.cn@gmail.com>

"Block for co-authors" has nothing to do with "文本块". 
正确的翻译应该是 ”锁定协作编辑“，或者简短些的 ”排他锁定“ 。